### PR TITLE
Reset Password tests added Anna Strik part

### DIFF
--- a/modules/_PageObjects/ResetPasswordPage.js
+++ b/modules/_PageObjects/ResetPasswordPage.js
@@ -4,21 +4,30 @@ class ResetPasswordPage extends AppPage {
 
 
     get h1() {
-        return $('//h1');
+        return browser.$('//h1');
     }
 
 
 // Miradil Omuraliev
     get emailReset(){
-        return $('//input[@placeholder="Enter your email address"]');
+        return browser.$('//input[@placeholder="Enter your email address"]');
     }
-    get sendButton() {
+    /*get sendButton() {
         return $('//button[@class="btn btn-primary"]');
     }
-    get h4(){
-        return $('//h4[@class="notification-title"]');
+     */
+    get sendButton() {
+        return browser.$('//button[contains(text(),"Send password reset email")]');
     }
-
+    get h4(){
+        return browser.$('//h4[@class="notification-title"]');
+    }
+    get email(){
+        return browser.$('//input[@name="email"]');
+    }
+    get requiredMsg(){
+        return browser.$('//div[contains(@class, "form")]//span[contains(text(), "Required")]');
+    }
 
     open(path) {
         super.open('https://stage.pasv.us/user/password/reset/request');

--- a/modules/user/recover_password/recoveryPassword.spec.js
+++ b/modules/user/recover_password/recoveryPassword.spec.js
@@ -31,6 +31,22 @@ describe('PASSWORD RECOVERY', () => {
         browser.pause(1000);
     });
 
+ // Anna Strik
+
+    it('should check if the button is displayed', () => {
+        expect($(ResetPasswordPage.sendButton).isDisplayed()).to.be.true;
+    });
+
+    it('should check if `Required` message is displayed if email field is empty', () => {
+        $(ResetPasswordPage.email).clearValue();
+        expect($(ResetPasswordPage.requiredMsg).isDisplayed()).to.be.true;
+    });
+
+    it('should check if the button is not clickable if email field is empty', () => {
+        expect($(ResetPasswordPage.sendButton).isEnabled()).to.be.false;
+        browser.pause(1000);
+    });
+
     // Miradil Omuraliev
 
     it('should check failed message `User not found` appears if entered email is not found in the database', () => {
@@ -46,8 +62,8 @@ describe('PASSWORD RECOVERY', () => {
     it('should check that user gets redirected to `CheckMail` page if correct email was entered', () => {
         ResetPasswordPage.emailReset.setValue('ooopartner00@mail.ru');
         ResetPasswordPage.sendButton.click();
-        browser.pause(500)
-        expect(CheckEmailPage.h1Check.getText()).eq('Check your email for a link to reset your password') ;
+        browser.pause(500);
+        expect(CheckEmailPage.h1Check.getText()).eq('Check your email for a link to reset your password');
     });
 
 });


### PR DESCRIPTION
in addition to my 3 tests in recoveryPassword.spec doc, I also  updated the selector for sendButton in ResetPasswordPage, it is now:
   get sendButton() {
        return browser.$('//button[contains(text(),"Send password reset email")]');

The old version of sendButton selector was (I put it in comments for a while, we can remove it):
 return $('//button[@class="btn btn-primary"]');

I believe it is not correct. Victor explained before that we should avoid including class names in selectors (although there are some rare exceptions). Also I remember that he mentioned exactly this button and this selector that "btn btn-primary" is bad name. As I see, this class name is even changing depending on the button state (enabled or disabled), so it is 100% incorrect.