### PR TITLE
Cards training adjusted

### DIFF
--- a/modules/_PageObjects/CardsTrainingPage.js
+++ b/modules/_PageObjects/CardsTrainingPage.js
@@ -2,7 +2,7 @@ import AppPage from '../AppPage';
 
 class CardsTrainingPage extends AppPage {
 
-  get title() {
+  get groupTitle() {
     return browser.$('//h1');
   }
 
@@ -18,19 +18,19 @@ class CardsTrainingPage extends AppPage {
     return browser.$('//div//button[contains(text(),"Show")]');
   }
 
-  get iKnow() {
+  get iKnowButton() {
     return browser.$('//button[contains(text(),"I know")]');
   }
 
-  get getRandom() {
+  get getRandomButton() {
     return browser.$('//button[contains(text(),"Get random next")]');
   }
 
-  get answer() {
+  get answerText() {
     return browser.$('//div[@class="result"]//p');
   }
 
-  get progress() {
+  get progressBar() {
     return browser.$('//div[@class="progress"]//div[@aria-valuenow]');
   }
 
@@ -38,19 +38,19 @@ class CardsTrainingPage extends AppPage {
     super.open('');
   }
 
-  getRandomClick() {
-    this.getRandom.click();
+  getRandomButtonClick() {
+    this.getRandomButton.click();
   }
 
-  iKnowClick() {
-    this.iKnow.click();
+  iKnowButtonClick() {
+    this.iKnowButton.click();
   }
 
   startTrainingClick() {
     this.startTrainingButton.click();
   }
 
-  showAnswerClick() {
+  showAnswerButtonClick() {
     this.showAnswerButton.click();
   }
 

--- a/modules/_PageObjects/CardsTrainingPage.js
+++ b/modules/_PageObjects/CardsTrainingPage.js
@@ -2,7 +2,7 @@ import AppPage from '../AppPage';
 
 class CardsTrainingPage extends AppPage {
 
-  get groupTitle() {
+  get title() {
     return browser.$('//h1');
   }
 
@@ -11,47 +11,47 @@ class CardsTrainingPage extends AppPage {
   }
 
   get startTrainingButton() {
-    return browser.$('//div//button[@class="btn btn-secondary btn-sm"]');
+    return browser.$('//button[contains(text(),"Start training")]');
   }
 
   get showAnswerButton() {
     return browser.$('//div//button[contains(text(),"Show")]');
   }
 
-  get iKnowButton() {
+  get iKnow() {
     return browser.$('//button[contains(text(),"I know")]');
   }
 
-  get getRandomButton() {
+  get getRandom() {
     return browser.$('//button[contains(text(),"Get random next")]');
   }
 
-  get answerText() {
+  get answer() {
     return browser.$('//div[@class="result"]//p');
   }
 
-  get progressBarValue1() {
-    return browser.$('//div[@class="container"]//div[@aria-valuenow="0"]');
-  }
-
-  get progressBarValue2() {
-    return browser.$('//div[@class="container"]//div[@aria-valuenow="33"]');
-  }
-
-  get progressBarValue3() {
-    return browser.$('//div[@class="container"]//div[@aria-valuenow="66"]');
+  get progress() {
+    return browser.$('//div[@class="progress"]//div[@aria-valuenow]');
   }
 
   open(path) {
     super.open('');
   }
 
-  getRandomButtonClick() {
-    this.getRandomButton.click();
+  getRandomClick() {
+    this.getRandom.click();
   }
 
-  iKnowButtonClick() {
-    this.iKnowButton.click();
+  iKnowClick() {
+    this.iKnow.click();
+  }
+
+  startTrainingClick() {
+    this.startTrainingButton.click();
+  }
+
+  showAnswerClick() {
+    this.showAnswerButton.click();
   }
 
 }

--- a/modules/cards/cards_training/CardsTraining.spec.js
+++ b/modules/cards/cards_training/CardsTraining.spec.js
@@ -5,14 +5,10 @@ import {student} from '../../user/login/loginRole_data';
 import CardsTrainingPage from '../../_PageObjects/CardsTrainingPage';
 import LoginPage from '../../_PageObjects/LoginPage';
 
-let progressBefore;
-let progressAfter;
-
-
 describe('CARDS TRAINING', () => {
-    before('login as a student', () => {
-      LoginPage.loginRole(student);
-    });
+  before('login as a student', () => {
+    LoginPage.loginRole(student);
+  });
 
   it('should click `Cards` tab in the navigation bar', () => {
     ProfilePage.cardsLink.click();
@@ -31,7 +27,7 @@ describe('CARDS TRAINING', () => {
   });
 
   it('should check a group title', () => {
-    expect(CardsTrainingPage.groupTitle.getText()).equal('TestGroup');
+    expect(CardsTrainingPage.title.getText()).equal('TestGroup');
   });
 
   it('should check if `Training` label is displayed', () => {
@@ -40,7 +36,7 @@ describe('CARDS TRAINING', () => {
 
   it('should click `Training` link', () => {
     CardsTrainingPage.trainingLabel.click();
-    browser.pause(500);
+    browser.pause(1000);
   });
 
   it('should check if `Start training` button is displayed', () => {
@@ -49,12 +45,12 @@ describe('CARDS TRAINING', () => {
   });
 
   it('should check if `Start training` button is clickable', () => {
-    CardsTrainingPage.startTrainingButton.click();
+    CardsTrainingPage.startTrainingClick();
     browser.pause(500);
   });
 
   it('should check if `I know` button is displayed', () => {
-    expect(CardsTrainingPage.iKnowButton.isDisplayed()).true;
+    expect(CardsTrainingPage.iKnow.isDisplayed()).true;
   });
 
   it('should check if `Show answer` button is displayed', () => {
@@ -62,52 +58,48 @@ describe('CARDS TRAINING', () => {
   });
 
   it('should check if `Get random next` button is displayed', () => {
-    expect(CardsTrainingPage.getRandomButton.isDisplayed()).true;
+    expect(CardsTrainingPage.getRandom.isDisplayed()).true;
   });
 
   it('should click `Show answer` button', () => {
-    CardsTrainingPage.showAnswerButton.click();
+    CardsTrainingPage.showAnswerClick();
     browser.pause(500);
   });
 
   it('should check if an answer is displayed', () => {
-    expect(CardsTrainingPage.answerText.isDisplayed()).true;
-    CardsTrainingPage.getRandomButtonClick();
+    expect(CardsTrainingPage.answer.isDisplayed()).true;
     browser.pause(500);
   });
 
-  it('should check a progress bar before clicking `I know`', () => {
-    progressBefore = CardsTrainingPage.progressBarValue1.getText();
+  it('should click `Get Random` button', () => {
+    CardsTrainingPage.getRandomClick();
     browser.pause(500);
   });
 
-  it('should click `I know`, and check if progress has changed from 0 to 33', () => {
-    CardsTrainingPage.iKnowButtonClick();
-    progressAfter = CardsTrainingPage.progressBarValue2.getText();
-    expect(progressAfter).to.not.equal(progressBefore);
+  it('should check if a progress bar is 0 from start and click `I know`', () => {
+    expect(CardsTrainingPage.progress.getAttribute('aria-valuenow')).eq('0');
+    browser.pause(1000);
+    CardsTrainingPage.iKnowClick();
+    browser.pause(500);
+
+  });
+
+  it('should check if a progress bar is 33 after 1st answer and click `I know`', () => {
+    expect(CardsTrainingPage.progress.getAttribute('aria-valuenow')).eq('33');
+    browser.pause(1000);
+    CardsTrainingPage.iKnowClick();
     browser.pause(500);
   });
 
-  it('should click `I know`, and check if progress has changed from 33 to 66', () => {
-    CardsTrainingPage.iKnowButtonClick();
-    progressBefore = CardsTrainingPage.progressBarValue2.getText();
-    progressAfter = CardsTrainingPage.progressBarValue3.getText();
-    expect(progressAfter).to.not.equal(progressBefore);
+  it('should check if a progress bar is 66 after 2nd answer and click `I know`', () => {
+    expect(CardsTrainingPage.progress.getAttribute('aria-valuenow')).eq('66');
+    browser.pause(1000);
+    CardsTrainingPage.iKnowClick();
     browser.pause(500);
   });
 
-  it('should click `I know`, and return to the `Training` page', () => {
-    CardsTrainingPage.iKnowButtonClick();
-    browser.pause(500);
-  });
-
-  it('should check if `Start training` button is displayed ', () => {
-    expect(CardsTrainingPage.startTrainingButton.isDisplayed()).true;
+  it('should check if `Start training` button is enabled', () => {
+    expect(CardsTrainingPage.startTrainingButton.isEnabled()).true;
     browser.pause(500);
   });
 });
-
-
-
-
-

--- a/modules/cards/cards_training/CardsTraining.spec.js
+++ b/modules/cards/cards_training/CardsTraining.spec.js
@@ -27,7 +27,7 @@ describe('CARDS TRAINING', () => {
   });
 
   it('should check a group title', () => {
-    expect(CardsTrainingPage.title.getText()).equal('TestGroup');
+    expect(CardsTrainingPage.groupTitle.getText()).equal('TestGroup');
   });
 
   it('should check if `Training` label is displayed', () => {
@@ -50,7 +50,7 @@ describe('CARDS TRAINING', () => {
   });
 
   it('should check if `I know` button is displayed', () => {
-    expect(CardsTrainingPage.iKnow.isDisplayed()).true;
+    expect(CardsTrainingPage.iKnowButton.isDisplayed()).true;
   });
 
   it('should check if `Show answer` button is displayed', () => {
@@ -58,43 +58,43 @@ describe('CARDS TRAINING', () => {
   });
 
   it('should check if `Get random next` button is displayed', () => {
-    expect(CardsTrainingPage.getRandom.isDisplayed()).true;
+    expect(CardsTrainingPage.getRandomButton.isDisplayed()).true;
   });
 
   it('should click `Show answer` button', () => {
-    CardsTrainingPage.showAnswerClick();
+    CardsTrainingPage.showAnswerButtonClick();
     browser.pause(500);
   });
 
   it('should check if an answer is displayed', () => {
-    expect(CardsTrainingPage.answer.isDisplayed()).true;
+    expect(CardsTrainingPage.answerText.isDisplayed()).true;
     browser.pause(500);
   });
 
   it('should click `Get Random` button', () => {
-    CardsTrainingPage.getRandomClick();
+    CardsTrainingPage.getRandomButtonClick();
     browser.pause(500);
   });
 
   it('should check if a progress bar is 0 from start and click `I know`', () => {
-    expect(CardsTrainingPage.progress.getAttribute('aria-valuenow')).eq('0');
+    expect(CardsTrainingPage.progressBar.getAttribute('aria-valuenow')).eq('0');
     browser.pause(1000);
-    CardsTrainingPage.iKnowClick();
+    CardsTrainingPage.iKnowButtonClick();
     browser.pause(500);
 
   });
 
   it('should check if a progress bar is 33 after 1st answer and click `I know`', () => {
-    expect(CardsTrainingPage.progress.getAttribute('aria-valuenow')).eq('33');
+    expect(CardsTrainingPage.progressBar.getAttribute('aria-valuenow')).eq('33');
     browser.pause(1000);
-    CardsTrainingPage.iKnowClick();
+    CardsTrainingPage.iKnowButtonClick();
     browser.pause(500);
   });
 
   it('should check if a progress bar is 66 after 2nd answer and click `I know`', () => {
-    expect(CardsTrainingPage.progress.getAttribute('aria-valuenow')).eq('66');
+    expect(CardsTrainingPage.progressBar.getAttribute('aria-valuenow')).eq('66');
     browser.pause(1000);
-    CardsTrainingPage.iKnowClick();
+    CardsTrainingPage.iKnowButtonClick();
     browser.pause(500);
   });
 


### PR DESCRIPTION
Поменяла геттер на StarTrainingButton с такого
return browser.$('//div//button[@Class="btn btn-secondary btn-sm"]');
на такой return browser.$('//button[contains(text(),"Start training")]');
Привязки к классу лучше избегать, где возможно, тем более к такому странному.

Заданные переменные let progressBefore; let progressAfter убрала. Я их изначально ставила, когда предполагала, что мы не будем сравнивать конкретные цифры (33%, 66% etc), а просто один раз посмотрим, что до клика на I know и после эти значения разные. Тогда в этом есть смысл, если мы не знаем и не проверяем конкретное значение после каждого клика. Если же мы проверяем каждый раз конкретное значение (33%, 66% etc), и это думаю правильнее, то зачем нам выводить это значение в переменную, это не надо, только усложняем тесты, поэтому вероятно или и фейлились через раз.

Делать отдельные селекторы (progress1, progress2, progress3...) '//div[@Class="container"]//div[@aria-valuenow="33"]' etc
для каждого состояния progress bar явно неправильно. Их же может быть очень много во-первых. А во-вторых нам же нужно именно это и проверить, что значение атрибута aria-valuenow меняется в зависимости от того сколько раз мы кликнули I know, то есть сначала оно =0, потом =33 (если 3 вопроса) и так далее. То есть с текстом (getText() ) это вообще сравнивать неправильно. Когда 0 текст вообще не высвечивается. Сейчас в тексте есть %, потом это могут убрать, и вообще потом могут сделать, что как текст 33%, 66% не будут видны на сайте, ведь это вовсе необязательно.
Правильнее будет брать общий селектор с общим атрибутом aria-valuenow и проверять как меняется значение этого атрибута после каждого клика (=0, =33, =66).
В связи с этим поменяла эти тест-кейсы след. образом: expect(CardsTrainingPage.progress.getAttribute('aria-valuenow')).eq('0') и так далее.

